### PR TITLE
Add structured schema layout

### DIFF
--- a/mutsea-database/migrations/README.md
+++ b/mutsea-database/migrations/README.md
@@ -1,0 +1,11 @@
+# Database Schema Organization
+
+This directory contains raw SQL schema files organized by backend. These files are
+intended for use with the migration system.
+
+- `postgresql/` contains PostgreSQL specific schemas.
+  - `ai/` – tables powering AI and machine learning features.
+  - `world/` – environmental and simulation state tables.
+  - `gameplay/` – player-centric gameplay tables.
+  - `analytics/` – performance and monitoring tables.
+  - `opensim/` – legacy OpenSim compatible schema.

--- a/mutsea-database/migrations/postgresql/ai/ai_decisions.sql
+++ b/mutsea-database/migrations/postgresql/ai/ai_decisions.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS ai_decisions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    decision_type VARCHAR(100) NOT NULL,
+    context_hash VARCHAR(64) NOT NULL,
+    input_data JSONB NOT NULL,
+    decision_data JSONB NOT NULL,
+    confidence_score DECIMAL(5,4) CHECK (confidence_score >= 0 AND confidence_score <= 1),
+    execution_time_ms INTEGER NOT NULL CHECK (execution_time_ms >= 0),
+    model_version VARCHAR(50) NOT NULL,
+    feedback_score DECIMAL(5,4) CHECK (feedback_score >= 0 AND feedback_score <= 1),
+    outcome_data JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_decision_type ON ai_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_context_hash ON ai_decisions(context_hash);
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_created_at ON ai_decisions(created_at);
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_confidence_score ON ai_decisions(confidence_score);
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_feedback_score ON ai_decisions(feedback_score);
+CREATE INDEX IF NOT EXISTS idx_ai_decisions_model_version ON ai_decisions(model_version);

--- a/mutsea-database/migrations/postgresql/ai/ai_global_mind_state.sql
+++ b/mutsea-database/migrations/postgresql/ai/ai_global_mind_state.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS ai_global_mind_state (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    world_consciousness JSONB NOT NULL,
+    player_psychology_state JSONB DEFAULT '{}',
+    story_director_state JSONB DEFAULT '{}',
+    resource_orchestrator_state JSONB DEFAULT '{}',
+    emergence_detection_state JSONB DEFAULT '{}',
+    decision_networks_state JSONB DEFAULT '{}',
+    global_objectives JSONB DEFAULT '{}',
+    adaptation_metrics JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_global_mind_state_timestamp ON ai_global_mind_state(timestamp);
+CREATE INDEX IF NOT EXISTS idx_ai_global_mind_state_world_consciousness ON ai_global_mind_state USING GIN(world_consciousness);
+CREATE INDEX IF NOT EXISTS idx_ai_global_mind_state_global_objectives ON ai_global_mind_state USING GIN(global_objectives);

--- a/mutsea-database/migrations/postgresql/ai/emergent_behaviors.sql
+++ b/mutsea-database/migrations/postgresql/ai/emergent_behaviors.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS emergent_behaviors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    behavior_type VARCHAR(100) NOT NULL,
+    detection_timestamp TIMESTAMPTZ NOT NULL,
+    participants JSONB NOT NULL, -- Array of participant IDs
+    trigger_conditions JSONB NOT NULL,
+    behavior_data JSONB NOT NULL,
+    complexity_score DECIMAL(5,4) CHECK (complexity_score >= 0 AND complexity_score <= 1),
+    impact_metrics JSONB DEFAULT '{}',
+    duration_seconds INTEGER CHECK (duration_seconds >= 0),
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_emergent_behaviors_behavior_type ON emergent_behaviors(behavior_type);
+CREATE INDEX IF NOT EXISTS idx_emergent_behaviors_detection_timestamp ON emergent_behaviors(detection_timestamp);
+CREATE INDEX IF NOT EXISTS idx_emergent_behaviors_complexity_score ON emergent_behaviors(complexity_score);
+CREATE INDEX IF NOT EXISTS idx_emergent_behaviors_participants ON emergent_behaviors USING GIN(participants);

--- a/mutsea-database/migrations/postgresql/ai/learning_data.sql
+++ b/mutsea-database/migrations/postgresql/ai/learning_data.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS learning_data (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subject_type VARCHAR(50) NOT NULL, -- 'player', 'npc', 'ecosystem', 'ai_system'
+    subject_id UUID NOT NULL,
+    learning_session_id UUID NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    input_data JSONB NOT NULL,
+    output_data JSONB NOT NULL,
+    feedback_data JSONB DEFAULT '{}',
+    learning_algorithm VARCHAR(100) NOT NULL,
+    performance_metrics JSONB DEFAULT '{}',
+    convergence_metrics JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_learning_data_subject_type ON learning_data(subject_type);
+CREATE INDEX IF NOT EXISTS idx_learning_data_subject_id ON learning_data(subject_id);
+CREATE INDEX IF NOT EXISTS idx_learning_data_learning_session_id ON learning_data(learning_session_id);
+CREATE INDEX IF NOT EXISTS idx_learning_data_timestamp ON learning_data(timestamp);
+CREATE INDEX IF NOT EXISTS idx_learning_data_learning_algorithm ON learning_data(learning_algorithm);
+CREATE INDEX IF NOT EXISTS idx_learning_data_composite ON learning_data(subject_type, subject_id, timestamp);

--- a/mutsea-database/migrations/postgresql/ai/npc_states.sql
+++ b/mutsea-database/migrations/postgresql/ai/npc_states.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS npc_states (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    npc_id UUID NOT NULL UNIQUE,
+    timestamp TIMESTAMPTZ NOT NULL,
+    personality_data JSONB NOT NULL,
+    memory_data JSONB DEFAULT '{}',
+    goal_data JSONB DEFAULT '{}',
+    relationship_data JSONB DEFAULT '{}',
+    emotional_state JSONB DEFAULT '{}',
+    behavioral_patterns JSONB DEFAULT '{}',
+    learning_progress JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_npc_states_npc_id ON npc_states(npc_id);
+CREATE INDEX IF NOT EXISTS idx_npc_states_timestamp ON npc_states(timestamp);
+CREATE INDEX IF NOT EXISTS idx_npc_states_personality_data ON npc_states USING GIN(personality_data);
+CREATE INDEX IF NOT EXISTS idx_npc_states_emotional_state ON npc_states USING GIN(emotional_state);

--- a/mutsea-database/migrations/postgresql/analytics/performance_metrics.sql
+++ b/mutsea-database/migrations/postgresql/analytics/performance_metrics.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS performance_metrics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    component_name VARCHAR(100) NOT NULL,
+    metric_type VARCHAR(100) NOT NULL,
+    metric_value DECIMAL(15,6) NOT NULL,
+    unit_of_measure VARCHAR(50),
+    context_data JSONB DEFAULT '{}',
+    threshold_data JSONB DEFAULT '{}',
+    alert_level VARCHAR(20) CHECK (alert_level IN ('info', 'warning', 'critical')),
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_performance_metrics_component_name ON performance_metrics(component_name);
+CREATE INDEX IF NOT EXISTS idx_performance_metrics_metric_type ON performance_metrics(metric_type);
+CREATE INDEX IF NOT EXISTS idx_performance_metrics_timestamp ON performance_metrics(timestamp);
+CREATE INDEX IF NOT EXISTS idx_performance_metrics_alert_level ON performance_metrics(alert_level);
+CREATE INDEX IF NOT EXISTS idx_performance_metrics_composite ON performance_metrics(component_name, metric_type, timestamp);

--- a/mutsea-database/migrations/postgresql/gameplay/player_behaviors.sql
+++ b/mutsea-database/migrations/postgresql/gameplay/player_behaviors.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS player_behaviors (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    player_id UUID NOT NULL,
+    session_id UUID NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    action_type VARCHAR(100) NOT NULL,
+    action_data JSONB NOT NULL,
+    context_data JSONB DEFAULT '{}',
+    performance_metrics JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_behaviors_player_id ON player_behaviors(player_id);
+CREATE INDEX IF NOT EXISTS idx_player_behaviors_session_id ON player_behaviors(session_id);
+CREATE INDEX IF NOT EXISTS idx_player_behaviors_timestamp ON player_behaviors(timestamp);
+CREATE INDEX IF NOT EXISTS idx_player_behaviors_action_type ON player_behaviors(action_type);
+CREATE INDEX IF NOT EXISTS idx_player_behaviors_action_data ON player_behaviors USING GIN(action_data);

--- a/mutsea-database/migrations/postgresql/gameplay/player_quest_progress.sql
+++ b/mutsea-database/migrations/postgresql/gameplay/player_quest_progress.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS player_quest_progress (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    player_id UUID NOT NULL,
+    quest_id UUID NOT NULL REFERENCES quests(id) ON DELETE CASCADE,
+    started_at TIMESTAMPTZ NOT NULL,
+    status VARCHAR(20) DEFAULT 'active' CHECK (status IN ('active', 'completed', 'failed', 'abandoned')),
+    progress_data JSONB DEFAULT '{}',
+    completed_objectives JSONB DEFAULT '{}',
+    choices_made JSONB DEFAULT '{}',
+    time_spent_minutes INTEGER DEFAULT 0,
+    difficulty_adjustments JSONB DEFAULT '{}',
+    ai_assistance_used JSONB DEFAULT '{}',
+    completion_metrics JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    completed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(player_id, quest_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_quest_progress_player_id ON player_quest_progress(player_id);
+CREATE INDEX IF NOT EXISTS idx_player_quest_progress_quest_id ON player_quest_progress(quest_id);
+CREATE INDEX IF NOT EXISTS idx_player_quest_progress_status ON player_quest_progress(status);
+CREATE INDEX IF NOT EXISTS idx_player_quest_progress_started_at ON player_quest_progress(started_at);

--- a/mutsea-database/migrations/postgresql/gameplay/quests.sql
+++ b/mutsea-database/migrations/postgresql/gameplay/quests.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS quests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    quest_type VARCHAR(100) NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    description TEXT,
+    objectives JSONB NOT NULL,
+    rewards JSONB DEFAULT '{}',
+    prerequisites JSONB DEFAULT '{}',
+    difficulty_level INTEGER CHECK (difficulty_level >= 1 AND difficulty_level <= 10),
+    estimated_duration_minutes INTEGER CHECK (estimated_duration_minutes > 0),
+    target_players JSONB DEFAULT '{}', -- Player types or specific IDs
+    generation_context JSONB DEFAULT '{}',
+    status VARCHAR(20) DEFAULT 'available' CHECK (status IN ('available', 'active', 'completed', 'failed', 'expired')),
+    completion_metrics JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_quests_quest_type ON quests(quest_type);
+CREATE INDEX IF NOT EXISTS idx_quests_status ON quests(status);
+CREATE INDEX IF NOT EXISTS idx_quests_difficulty_level ON quests(difficulty_level);
+CREATE INDEX IF NOT EXISTS idx_quests_target_players ON quests USING GIN(target_players);

--- a/mutsea-database/migrations/postgresql/gameplay/story_events.sql
+++ b/mutsea-database/migrations/postgresql/gameplay/story_events.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS story_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_type VARCHAR(100) NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    participants JSONB NOT NULL, -- Array of participant IDs
+    location_data JSONB DEFAULT '{}',
+    narrative_data JSONB NOT NULL,
+    choices_presented JSONB DEFAULT '{}',
+    player_decisions JSONB DEFAULT '{}',
+    outcomes JSONB DEFAULT '{}',
+    impact_metrics JSONB DEFAULT '{}',
+    generation_source VARCHAR(50) NOT NULL, -- 'ai_generated', 'player_triggered', 'emergent'
+    story_arc_id UUID,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_story_events_event_type ON story_events(event_type);
+CREATE INDEX IF NOT EXISTS idx_story_events_timestamp ON story_events(timestamp);
+CREATE INDEX IF NOT EXISTS idx_story_events_participants ON story_events USING GIN(participants);
+CREATE INDEX IF NOT EXISTS idx_story_events_generation_source ON story_events(generation_source);
+CREATE INDEX IF NOT EXISTS idx_story_events_story_arc_id ON story_events(story_arc_id);

--- a/mutsea-database/migrations/postgresql/opensim/opensim_compatibility.sql
+++ b/mutsea-database/migrations/postgresql/opensim/opensim_compatibility.sql
@@ -1,0 +1,596 @@
+-- OpenSim Compatibility Tables
+
+-- Regions table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS regions (
+    uuid UUID PRIMARY KEY,
+    regionHandle BIGINT NOT NULL UNIQUE,
+    regionName VARCHAR(32) NOT NULL,
+    regionRecvKey VARCHAR(128),
+    regionSendKey VARCHAR(128),
+    regionSecret VARCHAR(128),
+    regionDataURI VARCHAR(255),
+    serverIP VARCHAR(64),
+    serverPort INTEGER,
+    serverURI VARCHAR(255),
+    locX INTEGER NOT NULL,
+    locY INTEGER NOT NULL,
+    locZ INTEGER DEFAULT 0,
+    eastOverrideHandle BIGINT,
+    westOverrideHandle BIGINT,
+    southOverrideHandle BIGINT,
+    northOverrideHandle BIGINT,
+    regionAssetURI VARCHAR(255),
+    regionAssetRecvKey VARCHAR(128),
+    regionAssetSendKey VARCHAR(128),
+    regionUserURI VARCHAR(255),
+    regionUserRecvKey VARCHAR(128),
+    regionUserSendKey VARCHAR(128),
+    regionMapTexture UUID,
+    serverHttpPort INTEGER DEFAULT 9000,
+    serverRemotingPort INTEGER DEFAULT 8895,
+    access INTEGER DEFAULT 1,
+    ScopeID UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    sizeX INTEGER DEFAULT 256,
+    sizeY INTEGER DEFAULT 256,
+    flags INTEGER DEFAULT 0,
+    last_seen INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_regions_handle ON regions(regionHandle);
+CREATE INDEX IF NOT EXISTS idx_regions_name ON regions(regionName);
+CREATE INDEX IF NOT EXISTS idx_regions_location ON regions(locX, locY);
+
+-- User accounts table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS user_accounts (
+    PrincipalID UUID PRIMARY KEY,
+    ScopeID UUID NOT NULL,
+    FirstName VARCHAR(64) NOT NULL,
+    LastName VARCHAR(64) NOT NULL,
+    Email VARCHAR(64),
+    ServiceURLs TEXT,
+    Created INTEGER NOT NULL,
+    UserLevel INTEGER DEFAULT 0,
+    UserFlags INTEGER DEFAULT 0,
+    UserTitle VARCHAR(64) DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_accounts_name ON user_accounts(FirstName, LastName);
+CREATE INDEX IF NOT EXISTS idx_user_accounts_email ON user_accounts(Email);
+
+-- Assets table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS assets (
+    id UUID PRIMARY KEY,
+    name VARCHAR(64) NOT NULL,
+    description VARCHAR(64) NOT NULL,
+    assetType SMALLINT NOT NULL,
+    local BOOLEAN NOT NULL,
+    temporary BOOLEAN NOT NULL,
+    data BYTEA,
+    create_time INTEGER,
+    access_time INTEGER,
+    asset_flags INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_assets_name ON assets(name);
+CREATE INDEX IF NOT EXISTS idx_assets_type ON assets(assetType);
+CREATE INDEX IF NOT EXISTS idx_assets_local ON assets(local);
+
+-- Inventory folders table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS inventoryfolders (
+    folderID UUID PRIMARY KEY,
+    agentID UUID NOT NULL,
+    parentFolderID UUID NOT NULL,
+    folderName VARCHAR(64),
+    type SMALLINT NOT NULL DEFAULT 8,
+    version INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_inventoryfolders_agent ON inventoryfolders(agentID);
+CREATE INDEX IF NOT EXISTS idx_inventoryfolders_parent ON inventoryfolders(parentFolderID);
+
+-- Inventory items table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS inventoryitems (
+    inventoryID UUID PRIMARY KEY,
+    assetID UUID,
+    assetType INTEGER,
+    parentFolderID UUID NOT NULL,
+    avatarID UUID NOT NULL,
+    inventoryName VARCHAR(64),
+    inventoryDescription VARCHAR(128),
+    inventoryNextPermissions INTEGER,
+    inventoryCurrentPermissions INTEGER,
+    invType INTEGER,
+    creatorID UUID NOT NULL,
+    inventoryBasePermissions INTEGER NOT NULL,
+    inventoryEveryOnePermissions INTEGER NOT NULL,
+    inventoryGroupPermissions INTEGER NOT NULL,
+    salePrice INTEGER DEFAULT 0,
+    saleType SMALLINT DEFAULT 0,
+    creationDate INTEGER DEFAULT 0,
+    groupID UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    groupOwned BOOLEAN DEFAULT FALSE,
+    flags INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_inventoryitems_avatar ON inventoryitems(avatarID);
+CREATE INDEX IF NOT EXISTS idx_inventoryitems_folder ON inventoryitems(parentFolderID);
+
+-- Primitives table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS primitives (
+    UUID UUID PRIMARY KEY,
+    RegionUUID UUID,
+    CreationDate INTEGER,
+    Name VARCHAR(255),
+    Text VARCHAR(255),
+    Description VARCHAR(255),
+    SitName VARCHAR(255),
+    TouchName VARCHAR(255),
+    ObjectFlags INTEGER,
+    CreatorID UUID,
+    OwnerID UUID,
+    GroupID UUID,
+    LastOwnerID UUID,
+    OwnerMask INTEGER,
+    NextOwnerMask INTEGER,
+    GroupMask INTEGER,
+    EveryoneMask INTEGER,
+    BaseMask INTEGER,
+    PositionX DOUBLE PRECISION,
+    PositionY DOUBLE PRECISION,
+    PositionZ DOUBLE PRECISION,
+    GroupPositionX DOUBLE PRECISION,
+    GroupPositionY DOUBLE PRECISION,
+    GroupPositionZ DOUBLE PRECISION,
+    VelocityX DOUBLE PRECISION,
+    VelocityY DOUBLE PRECISION,
+    VelocityZ DOUBLE PRECISION,
+    AngularVelocityX DOUBLE PRECISION,
+    AngularVelocityY DOUBLE PRECISION,
+    AngularVelocityZ DOUBLE PRECISION,
+    AccelerationX DOUBLE PRECISION,
+    AccelerationY DOUBLE PRECISION,
+    AccelerationZ DOUBLE PRECISION,
+    RotationX DOUBLE PRECISION,
+    RotationY DOUBLE PRECISION,
+    RotationZ DOUBLE PRECISION,
+    RotationW DOUBLE PRECISION,
+    SitTargetOffsetX DOUBLE PRECISION,
+    SitTargetOffsetY DOUBLE PRECISION,
+    SitTargetOffsetZ DOUBLE PRECISION,
+    SitTargetOrientX DOUBLE PRECISION,
+    SitTargetOrientY DOUBLE PRECISION,
+    SitTargetOrientZ DOUBLE PRECISION,
+    SitTargetOrientW DOUBLE PRECISION,
+    ScaleX DOUBLE PRECISION,
+    ScaleY DOUBLE PRECISION,
+    ScaleZ DOUBLE PRECISION,
+    PCode INTEGER,
+    PathBegin INTEGER,
+    PathEnd INTEGER,
+    PathScaleX INTEGER,
+    PathScaleY INTEGER,
+    PathShearX INTEGER,
+    PathShearY INTEGER,
+    PathSkew INTEGER,
+    PathCurve INTEGER,
+    PathRadiusOffset INTEGER,
+    PathRevolutions INTEGER,
+    PathTaperX INTEGER,
+    PathTaperY INTEGER,
+    PathTwist INTEGER,
+    PathTwistBegin INTEGER,
+    ProfileBegin INTEGER,
+    ProfileEnd INTEGER,
+    ProfileCurve INTEGER,
+    ProfileHollow INTEGER,
+    Texture BYTEA,
+    ExtraParams BYTEA,
+    State INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_primitives_region ON primitives(RegionUUID);
+CREATE INDEX IF NOT EXISTS idx_primitives_owner ON primitives(OwnerID);
+CREATE INDEX IF NOT EXISTS idx_primitives_creator ON primitives(CreatorID);
+
+-- Terrain table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS terrain (
+    RegionUUID UUID NOT NULL,
+    Revision INTEGER NOT NULL,
+    Heightfield BYTEA,
+    PRIMARY KEY (RegionUUID, Revision)
+);
+
+-- Land/Parcels table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS land (
+    UUID UUID PRIMARY KEY,
+    RegionUUID UUID,
+    LocalLandID INTEGER,
+    Bitmap BYTEA,
+    Name VARCHAR(255),
+    Description VARCHAR(255),
+    OwnerUUID UUID,
+    IsGroupOwned BOOLEAN,
+    Area INTEGER,
+    AuctionID INTEGER,
+    Category INTEGER,
+    ClaimDate INTEGER,
+    ClaimPrice INTEGER,
+    GroupUUID UUID,
+    SalePrice INTEGER,
+    LandStatus INTEGER,
+    LandFlags INTEGER,
+    LandingType INTEGER,
+    MediaAutoScale INTEGER,
+    MediaTextureUUID UUID,
+    MediaURL VARCHAR(255),
+    MusicURL VARCHAR(255),
+    PassHours DOUBLE PRECISION,
+    PassPrice INTEGER,
+    SnapshotUUID UUID,
+    UserLocationX DOUBLE PRECISION,
+    UserLocationY DOUBLE PRECISION,
+    UserLocationZ DOUBLE PRECISION,
+    UserLookAtX DOUBLE PRECISION,
+    UserLookAtY DOUBLE PRECISION,
+    UserLookAtZ DOUBLE PRECISION,
+    AuthbuyerID UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    OtherCleanTime INTEGER DEFAULT 0,
+    Dwell DOUBLE PRECISION DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_land_region ON land(RegionUUID);
+CREATE INDEX IF NOT EXISTS idx_land_owner ON land(OwnerUUID);
+
+-- Land access list table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS landaccesslist (
+    LandUUID UUID,
+    AccessUUID UUID,
+    Flags INTEGER,
+    Expires INTEGER DEFAULT 0,
+    PRIMARY KEY (LandUUID, AccessUUID)
+);
+
+-- Additional OpenSim tables for complete compatibility
+
+-- Presence table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS presence (
+    UserID UUID NOT NULL,
+    RegionID UUID NOT NULL,
+    SessionID UUID NOT NULL,
+    SecureSessionID UUID NOT NULL,
+    PRIMARY KEY (UserID, RegionID)
+);
+
+-- GridUser table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS griduser (
+    UserID UUID PRIMARY KEY,
+    HomeRegionID UUID,
+    HomePosition VARCHAR(64),
+    HomeLookAt VARCHAR(64),
+    LastRegionID UUID,
+    LastPosition VARCHAR(64),
+    LastLookAt VARCHAR(64),
+    Online BOOLEAN,
+    Login INTEGER,
+    Logout INTEGER
+);
+
+-- Friends table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS friends (
+    PrincipalID UUID,
+    Friend VARCHAR(255),
+    Flags INTEGER NOT NULL DEFAULT 0,
+    Offered VARCHAR(32) NOT NULL DEFAULT 0,
+    PRIMARY KEY (PrincipalID, Friend)
+);
+
+-- Groups table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS os_groups_groups (
+    GroupID UUID PRIMARY KEY,
+    Location VARCHAR(255) DEFAULT '',
+    Name VARCHAR(255) NOT NULL,
+    Charter TEXT,
+    InsigniaID UUID,
+    FounderID UUID,
+    MembershipFee INTEGER DEFAULT 0,
+    OpenEnrollment VARCHAR(255) DEFAULT 'false',
+    ShowInList INTEGER DEFAULT 1,
+    AllowPublish INTEGER DEFAULT 1,
+    MaturePublish INTEGER DEFAULT 1,
+    OwnerRoleID UUID
+);
+
+-- Group members table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS os_groups_membership (
+    GroupID UUID,
+    PrincipalID UUID,
+    SelectedRoleID UUID,
+    Contribution INTEGER DEFAULT 0,
+    ListInProfile INTEGER DEFAULT 1,
+    AcceptNotices INTEGER DEFAULT 1,
+    AccessToken UUID,
+    PRIMARY KEY (GroupID, PrincipalID)
+);
+
+-- Group roles table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS os_groups_roles (
+    GroupID UUID,
+    RoleID UUID,
+    Name VARCHAR(255) NOT NULL,
+    Description VARCHAR(255),
+    Title VARCHAR(255),
+    Powers BIGINT DEFAULT 0,
+    PRIMARY KEY (GroupID, RoleID)
+);
+
+-- Group role members table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS os_groups_rolemembership (
+    GroupID UUID,
+    RoleID UUID,
+    PrincipalID UUID,
+    PRIMARY KEY (GroupID, RoleID, PrincipalID)
+);
+
+-- Group invites table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS os_groups_invites (
+    InviteID UUID PRIMARY KEY,
+    GroupID UUID NOT NULL,
+    RoleID UUID NOT NULL,
+    PrincipalID UUID NOT NULL,
+    TMStamp INTEGER NOT NULL DEFAULT 0
+);
+
+-- Group notices table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS os_groups_notices (
+    GroupID UUID,
+    NoticeID UUID,
+    TMStamp INTEGER NOT NULL,
+    FromName VARCHAR(255) NOT NULL,
+    Subject VARCHAR(255) NOT NULL,
+    Message TEXT NOT NULL,
+    HasAttachment INTEGER NOT NULL DEFAULT 0,
+    AttachmentType INTEGER NOT NULL DEFAULT 0,
+    AttachmentName VARCHAR(128) NOT NULL DEFAULT '',
+    AttachmentItemID UUID NOT NULL,
+    AttachmentOwnerID UUID NOT NULL,
+    PRIMARY KEY (GroupID, NoticeID)
+);
+
+-- Estate settings table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS estate_settings (
+    EstateID INTEGER PRIMARY KEY,
+    EstateName VARCHAR(64) DEFAULT '',
+    AbuseEmailToEstateOwner BOOLEAN DEFAULT FALSE,
+    DenyAnonymous BOOLEAN DEFAULT FALSE,
+    ResetHomeOnTeleport BOOLEAN DEFAULT FALSE,
+    FixedSun BOOLEAN DEFAULT FALSE,
+    DenyTransacted BOOLEAN DEFAULT FALSE,
+    BlockDwell BOOLEAN DEFAULT FALSE,
+    DenyIdentified BOOLEAN DEFAULT FALSE,
+    AllowVoice BOOLEAN DEFAULT TRUE,
+    UseGlobalTime BOOLEAN DEFAULT TRUE,
+    PricePerMeter INTEGER DEFAULT 1,
+    TaxFree BOOLEAN DEFAULT FALSE,
+    AllowDirectTeleport BOOLEAN DEFAULT TRUE,
+    RedirectGridX INTEGER DEFAULT 0,
+    RedirectGridY INTEGER DEFAULT 0,
+    ParentEstateID INTEGER DEFAULT 1,
+    SunPosition DOUBLE PRECISION DEFAULT 0.0,
+    EstateSkipScripts BOOLEAN DEFAULT FALSE,
+    BillableFactor DOUBLE PRECISION DEFAULT 1.0,
+    PublicAccess BOOLEAN DEFAULT TRUE,
+    AbuseEmail VARCHAR(255) DEFAULT '',
+    EstateOwner UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    DenyMinors BOOLEAN DEFAULT FALSE,
+    AllowLandmark BOOLEAN DEFAULT TRUE,
+    AllowParcelChanges BOOLEAN DEFAULT TRUE,
+    AllowSetHome BOOLEAN DEFAULT TRUE
+);
+
+-- Estate map table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS estate_map (
+    RegionID UUID PRIMARY KEY,
+    EstateID INTEGER NOT NULL
+);
+
+-- Estate users table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS estate_users (
+    EstateID INTEGER,
+    uuid UUID,
+    PRIMARY KEY (EstateID, uuid)
+);
+
+-- Estate groups table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS estate_groups (
+    EstateID INTEGER,
+    uuid UUID,
+    PRIMARY KEY (EstateID, uuid)
+);
+
+-- Estate managers table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS estate_managers (
+    EstateID INTEGER,
+    uuid UUID,
+    PRIMARY KEY (EstateID, uuid)
+);
+
+-- Estate bans table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS estate_ban (
+    EstateID INTEGER,
+    bannedUUID UUID,
+    bannedIp VARCHAR(16),
+    bannedIpHostMask VARCHAR(16),
+    bannedNameMask VARCHAR(64),
+    PRIMARY KEY (EstateID, bannedUUID)
+);
+
+-- Authentication table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS auth (
+    UUID UUID PRIMARY KEY,
+    passwordHash VARCHAR(32),
+    passwordSalt VARCHAR(32),
+    webLoginKey UUID,
+    accountType VARCHAR(32) DEFAULT 'UserAccount'
+);
+
+-- Avatar appearances table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS avatarappearances (
+    Owner UUID PRIMARY KEY,
+    Serial INTEGER DEFAULT 0,
+    Visual_Params BYTEA,
+    Texture BYTEA,
+    Avatar_Height DOUBLE PRECISION DEFAULT 0,
+    Body_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Body_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Skin_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Skin_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Hair_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Hair_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Eyes_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Eyes_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Shirt_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Shirt_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Pants_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Pants_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Shoes_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Shoes_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Socks_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Socks_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Jacket_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Jacket_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Gloves_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Gloves_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Undershirt_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Undershirt_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Underpants_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Underpants_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Skirt_Item UUID DEFAULT '00000000-0000-0000-0000-000000000000',
+    Skirt_Asset UUID DEFAULT '00000000-0000-0000-0000-000000000000'
+);
+
+-- Avatar attachments table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS avatarattachments (
+    UUID UUID,
+    attachpoint INTEGER,
+    item UUID,
+    asset UUID,
+    PRIMARY KEY (UUID, attachpoint)
+);
+
+-- Mute list table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS mute (
+    agentID UUID NOT NULL,
+    muteID UUID NOT NULL,
+    muteName VARCHAR(64) NOT NULL,
+    muteType INTEGER NOT NULL DEFAULT 1,
+    muteFlags INTEGER NOT NULL DEFAULT 0,
+    mutestamp INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (agentID, muteID, muteName)
+);
+
+-- Offline messages table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS im_offline (
+    ID SERIAL PRIMARY KEY,
+    PrincipalID UUID NOT NULL,
+    Message TEXT NOT NULL,
+    TMStamp INTEGER NOT NULL
+);
+
+-- Migrations table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS migrations (
+    name VARCHAR(100) PRIMARY KEY,
+    version INTEGER NOT NULL
+);
+
+-- Profile data table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS classifieds (
+    classifieduuid UUID PRIMARY KEY,
+    creatoruuid UUID NOT NULL,
+    creationdate INTEGER NOT NULL,
+    expirationdate INTEGER NOT NULL,
+    category VARCHAR(20) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    parceluuid UUID NOT NULL,
+    parentestate INTEGER NOT NULL,
+    snapshotuuid UUID NOT NULL,
+    simname VARCHAR(255) NOT NULL,
+    posglobal VARCHAR(255) NOT NULL,
+    parcelname VARCHAR(255) NOT NULL,
+    classifiedflags INTEGER NOT NULL,
+    priceforlisting INTEGER NOT NULL
+);
+
+-- User picks table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS userpicks (
+    pickuuid UUID PRIMARY KEY,
+    creatoruuid UUID NOT NULL,
+    toppick BOOLEAN NOT NULL,
+    parceluuid UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT NOT NULL,
+    snapshotuuid UUID NOT NULL,
+    user VARCHAR(255) NOT NULL,
+    originalname VARCHAR(255) NOT NULL,
+    simname VARCHAR(255) NOT NULL,
+    posglobal VARCHAR(255) NOT NULL,
+    sortorder INTEGER NOT NULL,
+    enabled BOOLEAN NOT NULL,
+    gatekeeper VARCHAR(255)
+);
+
+-- User notes table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS usernotes (
+    useruuid UUID NOT NULL,
+    targetuuid UUID NOT NULL,
+    notes TEXT NOT NULL,
+    PRIMARY KEY (useruuid, targetuuid)
+);
+
+-- User settings table (OpenSim compatible)
+CREATE TABLE IF NOT EXISTS usersettings (
+    useruuid UUID PRIMARY KEY,
+    imviaemail BOOLEAN NOT NULL,
+    visible BOOLEAN NOT NULL,
+    email VARCHAR(254) NOT NULL
+);
+
+-- Create foreign key constraints for data integrity
+ALTER TABLE estate_map ADD CONSTRAINT fk_estate_map_estate 
+    FOREIGN KEY (EstateID) REFERENCES estate_settings(EstateID);
+
+ALTER TABLE estate_users ADD CONSTRAINT fk_estate_users_estate 
+    FOREIGN KEY (EstateID) REFERENCES estate_settings(EstateID);
+
+ALTER TABLE estate_groups ADD CONSTRAINT fk_estate_groups_estate 
+    FOREIGN KEY (EstateID) REFERENCES estate_settings(EstateID);
+
+ALTER TABLE estate_managers ADD CONSTRAINT fk_estate_managers_estate 
+    FOREIGN KEY (EstateID) REFERENCES estate_settings(EstateID);
+
+ALTER TABLE estate_ban ADD CONSTRAINT fk_estate_ban_estate 
+    FOREIGN KEY (EstateID) REFERENCES estate_settings(EstateID);
+
+-- Create additional indexes for performance
+CREATE INDEX IF NOT EXISTS idx_land_access_list_land ON landaccesslist(LandUUID);
+CREATE INDEX IF NOT EXISTS idx_presence_session ON presence(SessionID);
+CREATE INDEX IF NOT EXISTS idx_griduser_region ON griduser(LastRegionID);
+CREATE INDEX IF NOT EXISTS idx_friends_friend ON friends(Friend);
+CREATE INDEX IF NOT EXISTS idx_groups_name ON os_groups_groups(Name);
+CREATE INDEX IF NOT EXISTS idx_group_membership_principal ON os_groups_membership(PrincipalID);
+CREATE INDEX IF NOT EXISTS idx_estate_map_estate ON estate_map(EstateID);
+CREATE INDEX IF NOT EXISTS idx_avatar_attachments_item ON avatarattachments(item);
+CREATE INDEX IF NOT EXISTS idx_im_offline_principal ON im_offline(PrincipalID);
+CREATE INDEX IF NOT EXISTS idx_classifieds_creator ON classifieds(creatoruuid);
+CREATE INDEX IF NOT EXISTS idx_userpicks_creator ON userpicks(creatoruuid);
+
+-- Comments for future AI integration
+COMMENT ON TABLE regions IS 'OpenSim region definitions - base for AI-enhanced world generation';
+COMMENT ON TABLE user_accounts IS 'OpenSim user accounts - extended with AI behavior tracking';
+COMMENT ON TABLE primitives IS 'OpenSim primitive objects - enhanced with AI-driven behaviors';
+COMMENT ON TABLE assets IS 'OpenSim asset storage - supports AI-generated content';
+COMMENT ON TABLE land IS 'OpenSim land parcels - managed by AI economy systems';
+
+-- Version tracking for schema evolution
+INSERT INTO migrations (name, version) VALUES ('opensim_compatibility', 1) 
+ON CONFLICT (name) DO UPDATE SET version = EXCLUDED.version;

--- a/mutsea-database/migrations/postgresql/world/biomes.sql
+++ b/mutsea-database/migrations/postgresql/world/biomes.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS biomes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    biome_type VARCHAR(50) NOT NULL,
+    climate_data JSONB NOT NULL,
+    terrain_data JSONB NOT NULL,
+    species_data JSONB DEFAULT '{}',
+    resource_distribution JSONB DEFAULT '{}',
+    carrying_capacity_base INTEGER CHECK (carrying_capacity_base >= 0),
+    environmental_factors JSONB DEFAULT '{}',
+    generation_parameters JSONB DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_biomes_name ON biomes(name);
+CREATE INDEX IF NOT EXISTS idx_biomes_biome_type ON biomes(biome_type);
+CREATE INDEX IF NOT EXISTS idx_biomes_climate_data ON biomes USING GIN(climate_data);
+CREATE INDEX IF NOT EXISTS idx_biomes_terrain_data ON biomes USING GIN(terrain_data);

--- a/mutsea-database/migrations/postgresql/world/ecosystem_states.sql
+++ b/mutsea-database/migrations/postgresql/world/ecosystem_states.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS ecosystem_states (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    biome_id UUID NOT NULL,
+    population_data JSONB NOT NULL,
+    resource_data JSONB NOT NULL,
+    interaction_data JSONB DEFAULT '{}',
+    health_metrics JSONB DEFAULT '{}',
+    biodiversity_index DECIMAL(5,4) CHECK (biodiversity_index >= 0 AND biodiversity_index <= 1),
+    carrying_capacity INTEGER CHECK (carrying_capacity >= 0),
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ecosystem_states_biome_id ON ecosystem_states(biome_id);
+CREATE INDEX IF NOT EXISTS idx_ecosystem_states_timestamp ON ecosystem_states(timestamp);
+CREATE INDEX IF NOT EXISTS idx_ecosystem_states_biodiversity_index ON ecosystem_states(biodiversity_index);
+CREATE INDEX IF NOT EXISTS idx_ecosystem_states_population_data ON ecosystem_states USING GIN(population_data);

--- a/mutsea-database/migrations/postgresql/world/world_states.sql
+++ b/mutsea-database/migrations/postgresql/world/world_states.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS world_states (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    simulation_state JSONB NOT NULL,
+    environmental_state JSONB NOT NULL,
+    ecosystem_state JSONB NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_world_states_timestamp ON world_states(timestamp);
+CREATE INDEX IF NOT EXISTS idx_world_states_created_at ON world_states(created_at);
+CREATE INDEX IF NOT EXISTS idx_world_states_simulation_state ON world_states USING GIN(simulation_state);
+CREATE INDEX IF NOT EXISTS idx_world_states_environmental_state ON world_states USING GIN(environmental_state);
+CREATE INDEX IF NOT EXISTS idx_world_states_ecosystem_state ON world_states USING GIN(ecosystem_state);


### PR DESCRIPTION
## Summary
- reorganize SQL schema files under `migrations/postgresql`
- add README describing schema organization

## Testing
- `cargo test -p mutsea-tests --quiet` *(fails: failed to select a version for `mutsea-core`)*

------
https://chatgpt.com/codex/tasks/task_e_68442a8391408332bb10c22a3c9ff290