### PR TITLE
Implement AI schema initialization

### DIFF
--- a/mutsea-database/src/lib.rs
+++ b/mutsea-database/src/lib.rs
@@ -60,6 +60,11 @@ impl DatabaseService {
         self.manager.migrate().await
     }
 
+    /// Initialize AI-specific schema
+    pub async fn initialize_ai_schema(&self) -> DatabaseResult<()> {
+        self.manager.initialize_ai_schema().await
+    }
+
     /// Get database metrics
     pub async fn get_metrics(&self) -> DatabaseMetrics {
         self.manager.get_metrics().await

--- a/mutsea-database/src/manager.rs
+++ b/mutsea-database/src/manager.rs
@@ -92,6 +92,30 @@ impl DatabaseManager {
         Ok(())
     }
 
+    /// Initialize AI-specific database schema
+    pub async fn initialize_ai_schema(&self) -> DatabaseResult<()> {
+        info!("Initializing AI database schema for {} backend", self.backend.as_str());
+
+        if self.backend != DatabaseBackend::PostgreSQL {
+            return Err(DatabaseError::UnsupportedBackend(self.backend.as_str().to_string()));
+        }
+
+        let sql_files = [
+            include_str!("../migrations/postgresql/ai/ai_decisions.sql"),
+            include_str!("../migrations/postgresql/ai/ai_global_mind_state.sql"),
+            include_str!("../migrations/postgresql/ai/emergent_behaviors.sql"),
+            include_str!("../migrations/postgresql/ai/learning_data.sql"),
+            include_str!("../migrations/postgresql/ai/npc_states.sql"),
+        ];
+
+        for sql in sql_files.iter() {
+            self.pool.execute_raw(sql).await?;
+        }
+
+        info!("AI schema initialization completed");
+        Ok(())
+    }
+
     /// Get database metrics
     pub async fn get_metrics(&self) -> DatabaseMetrics {
         let mut metrics = self.metrics.read().await.clone();


### PR DESCRIPTION
## Summary
- add AI schema initialization in database manager and service

## Testing
- `cargo test -p mutsea-database --no-run` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_684436445cdc8332b7d588b63ac1acc8